### PR TITLE
Se cambia la versión del contendor Ubuntu por 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 WORKDIR /usr/src/app
 RUN chmod 777 /usr/src/app


### PR DESCRIPTION
El bot dejo de funcionar por actulizaciones en Heroku, se cambio a la nueva versión de Ubuntu para corregir el problema